### PR TITLE
Removed bottleneck in PlatformEventMulticaster

### DIFF
--- a/platform-core/src/main/java/org/trpr/platform/core/impl/event/AbstractApplicationEventMulticaster.java
+++ b/platform-core/src/main/java/org/trpr/platform/core/impl/event/AbstractApplicationEventMulticaster.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2012-2016, the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.trpr.platform.core.impl.event;
+
+import org.springframework.context.ApplicationListener;
+import org.springframework.context.event.ApplicationEventMulticaster;
+
+import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+/**
+ * Abstract implementation of the {@link ApplicationEventMulticaster} interface,
+ * providing the basic listener registration facility. This is thread unsafe version of
+ * Spring's {@link org.springframework.context.event.AbstractApplicationEventMulticaster}
+ * as Spring's version has global locks in critical flows like {@link #getApplicationListeners}.
+ * <p/>
+ * <p>Doesn't permit multiple instances of the same listener by default,
+ * as it keeps listeners in a linked Set.
+ * <p/>
+ * <p>Implementing ApplicationEventMulticaster's actual {@link #multicastEvent} method
+ * is left to subclasses. {@link PlatformEventMulticaster} simply multicasts
+ * all events to all registered listeners, invoking them in the calling thread.
+ * <p/>
+ * @author Mohan Kumar Pandian
+ * @version 2.0.0, 14/10/2016
+ */
+public abstract class AbstractApplicationEventMulticaster implements ApplicationEventMulticaster {
+    private final Set<ApplicationListener<?>> applicationListeners;
+
+    public AbstractApplicationEventMulticaster() {
+        this.applicationListeners = new LinkedHashSet<>();
+    }
+
+    @Override
+    public void addApplicationListener(ApplicationListener<?> listener) {
+        this.applicationListeners.add(listener);
+    }
+
+    @Override
+    public void addApplicationListenerBean(String listenerBeanName) {
+        // No support for listener bean by name
+    }
+
+    @Override
+    public void removeApplicationListener(ApplicationListener<?> listener) {
+        this.applicationListeners.remove(listener);
+    }
+
+    @Override
+    public void removeApplicationListenerBean(String listenerBeanName) {
+        // No support for listener bean by name
+    }
+
+    @Override
+    public void removeAllListeners() {
+        this.applicationListeners.clear();
+    }
+
+    /**
+     * Thread unsafe version of spring's AbstractApplicationEventMulticaster
+     *
+     * @return Registered application listeners (and not beans)
+     * @see org.springframework.context.event.AbstractApplicationEventMulticaster#getApplicationListeners()
+     */
+    protected Collection<ApplicationListener<?>> getApplicationListeners() {
+        return applicationListeners;
+    }
+}

--- a/platform-core/src/main/java/org/trpr/platform/core/impl/event/PlatformEventMulticaster.java
+++ b/platform-core/src/main/java/org/trpr/platform/core/impl/event/PlatformEventMulticaster.java
@@ -23,11 +23,10 @@ import org.trpr.platform.core.spi.event.EndpointEventConsumer;
 import org.trpr.platform.core.spi.logging.Logger;
 import org.springframework.context.ApplicationEvent;
 import org.springframework.context.ApplicationListener;
-import org.springframework.context.event.AbstractApplicationEventMulticaster;
 import org.springframework.core.ResolvableType;
 
 /**
- * The <code>PlatformEventMulticaster</code> is a sub-type of the Spring {@link AbstractApplicationEventMulticaster} that permits specifying 
+ * The <code>PlatformEventMulticaster</code> is a sub-type of {@link AbstractApplicationEventMulticaster} that permits specifying
  * URI endpoints of all subscriptions that this multi-caster entertains. 
  * 
  * Platform {@link EndpointEventConsumer} instances registered in the same ApplicationContext may specify subscription URIs. This multi-caster
@@ -77,7 +76,7 @@ public class PlatformEventMulticaster extends AbstractApplicationEventMulticaste
 				return;				
 			}
 			for (Iterator<ApplicationListener<?>> iterator = getApplicationListeners().iterator(); iterator.hasNext();) {
-	            ApplicationListener<?> listener = (ApplicationListener<?>) iterator.next();	
+	            ApplicationListener<?> listener = iterator.next();
 	            if (listener instanceof EndpointEventConsumer) {
 	            	if (isSubscriptionMatch(eventEndpointURI, ((EndpointEventConsumer)listener).getSubscriptions())) {
 	            		((EndpointEventConsumer)listener).onApplicationEvent(platformApplicationEvent);

--- a/serviceframework-core/src/main/java/org/trpr/platform/servicefw/impl/event/PlatformEventMulticaster.java
+++ b/serviceframework-core/src/main/java/org/trpr/platform/servicefw/impl/event/PlatformEventMulticaster.java
@@ -20,15 +20,15 @@ import java.util.Iterator;
 
 import org.springframework.context.ApplicationEvent;
 import org.springframework.context.ApplicationListener;
-import org.springframework.context.event.AbstractApplicationEventMulticaster;
 import org.springframework.core.ResolvableType;
+import org.trpr.platform.core.impl.event.AbstractApplicationEventMulticaster;
 import org.trpr.platform.core.impl.event.PlatformApplicationEvent;
 import org.trpr.platform.core.impl.logging.LogFactory;
 import org.trpr.platform.core.spi.logging.Logger;
 import org.trpr.platform.servicefw.spi.event.ServiceEventConsumer;
 
 /**
- * The <code>PlatformEventMulticaster</code> is a sub-type of the Spring {@link AbstractApplicationEventMulticaster} that permits specifying 
+ * The <code>PlatformEventMulticaster</code> is a sub-type of {@link AbstractApplicationEventMulticaster} that permits specifying
  * URI endpoints of all subscriptions that this multi-caster entertains. 
  * 
  * Platform {@link ServiceEventConsumer} instances registered in the same ApplicationContext may specify subscription URIs. This multi-caster


### PR DESCRIPTION
Issue:
Spring's AbstractApplicationEventMulticaster has [global locks](https://github.com/spring-projects/spring-framework/commit/52124fa31b17fee7b6ffdfc92ec9fe14ad9a0561#diff-2047c68c136729519797ac17b17a5bccL115) to support dynamically registering/deregistering even listeners and to avoid deadlock in multi-threaded singleton creation/destruction.

In PlatformEventMulticaster.java, we call spring's AbstractApplicationEventMulticaster#getApplicationListeners() which becomes a bottleneck when multiple threads generate events at a very higher rate.

Ex: In phantom which uses trooper, whenever a sync command is executed, it generates and publishes events which gets consumed by subscribers like RequestLogger and then to zipkin span collectors. This whole flow happens in calling thread in synchronous fashion. Having a global lock/bottleneck here blocks threads and reduces concurrency.

Fix:
Have our own AbstractApplicationEventMulticaster which is thread unsafe (no synchronization).

Contention measured using Flight Recorder
<img width="1280" alt="screen shot 2016-09-10 at 2 46 12 pm" src="https://cloud.githubusercontent.com/assets/7262197/19380107/423d1f38-9213-11e6-9081-7a060286e2b2.png">
