### PR TITLE
Use beDefinitionsContext.close() instead of beDefinitionsContext.destroy()

### DIFF
--- a/runtime-core/src/main/java/org/trpr/platform/runtime/impl/container/spring/SpringContainerImpl.java
+++ b/runtime-core/src/main/java/org/trpr/platform/runtime/impl/container/spring/SpringContainerImpl.java
@@ -141,7 +141,7 @@ public class SpringContainerImpl implements Container {
 					beManager.addBootstrapExtensionInfo((BootstrapExtensionInfo)beDefinitionsContext.getBean(beInfo));
 				}
 				// destroy the beDefinitionsContext as we dont need it anymore
-				beDefinitionsContext.destroy();
+				beDefinitionsContext.close();
 			} catch (Exception e) {
 				LOGGER.error("Error in loading BootStrap Extension File. Ignoring contents of : " + beFile.getAbsolutePath() + " .Error message : " + e.getMessage(), e);
 			}


### PR DESCRIPTION
destroy method is deprecated and it makes the module incompatible with Java 17
The runtime-core module builds and fits in with Java 17 project after this change
https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/context/support/AbstractApplicationContext.html
![image](https://user-images.githubusercontent.com/20877996/182299727-c77b8954-fb00-4595-a213-ea8cabaab04a.png)
